### PR TITLE
fixes for iOS, edit-config tree import/export, new/delete tree #94

### DIFF
--- a/html/edit-config.html
+++ b/html/edit-config.html
@@ -439,6 +439,7 @@
     <!-- MAIN SCRIPTS -->
     <script src="bower_components/underscore/underscore-min.js"></script>
     <script src="bower_components/showdown/dist/showdown.min.js"></script>
+    <script src="js/nodelib.js"></script>
     <script src="js/lib/translate.js"></script>
     <script src="js/lib/sanitize-html.js"></script>
     <script src="js/lib/zipjs/zip.js"></script>

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -827,6 +827,10 @@ function _move_sub_speak(text, voice_options) {
   }
   if(this.meta['audio']) {
     return speaku.play_audio(this.meta['audio'], voice_options)
+      .catch(function (err) {
+        console.error(err);
+        return speaku.simple_speak(_t("Could not play the input audio"), voice_options);
+      });
   } else {
     return speaku.simple_speak(text, voice_options);
   }
@@ -854,7 +858,11 @@ function _move_sub_speak2(type, override_msg) {
     audio = null;
   }
   if(audio) {
-    return  speaku.play_audio(audio, opts);
+    return  speaku.play_audio(audio, opts)
+      .catch(function (err) {
+        console.error(err);
+        return speaku.simple_speak(_t("Could not play the input audio"), opts);
+      });
   } else if(text) {
     return speaku.simple_speak(text, opts);
   }

--- a/html/jsx/nodelib.js
+++ b/html/jsx/nodelib.js
@@ -1,4 +1,5 @@
 import * as SortedArrayFuncs from "sorted-array-functions";
+import path from "path";
 
 window.SortedArrayFuncs = SortedArrayFuncs;
-
+window.path = path;

--- a/html/quick-setup.html
+++ b/html/quick-setup.html
@@ -151,6 +151,7 @@
     <!-- MAIN SCRIPTS -->
     <script src="bower_components/underscore/underscore-min.js"></script>
     <script src="bower_components/showdown/dist/showdown.min.js"></script>
+    <script src="js/nodelib.js"></script>
     <script src="js/lib/translate.js"></script>
     <script src="js/lib/sanitize-html.js"></script>
     <script src="js/lib/zipjs/zip.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6146,6 +6146,14 @@
         "url": "^0.11.0",
         "util": "^0.10.3",
         "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "path-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+          "dev": true
+        }
       }
     },
     "node-releases": {
@@ -6604,10 +6612,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
+      "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/AceCentre/pasco#readme",
   "dependencies": {
+    "path-browserify": "^1.0.0",
     "plist": "3.0.1",
     "sorted-array-functions": "^1.2.0"
   },


### PR DESCRIPTION
import and export tools implementation has simplified by removing the need for
directory to define a tree.
Now tree can be at root of zip file.

import function detects first `.md` file and accepts it as a tree. Then loads all the files required by that tree (relative to where it's located at zip file). And modifies audio paths to match new loaded files.