### PR TITLE
fix #134 & #100, override output to (headphone,builtinspeaker or default), +enhancement

### DIFF
--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -7,7 +7,7 @@
     <author email="hossein@aminbros.com" href="https://github.com/hosseinamin/">
         Hossein Amin
     </author>
-    <preference name="KeepAVAudioSessionAlwaysActive" value="true" />
+    <preference name="CordovaMediaIgnoreAVAudioSession" value="true" />
     <preference name="KeyboardDisplayRequiresUserAction" value="false" />
     <preference name="DisallowOverscroll" value="true" />
     <preference name="MediaPlaybackRequiresUserAction" value="false" />

--- a/html/edit-config.html
+++ b/html/edit-config.html
@@ -60,6 +60,9 @@
             <div class="col-sm-6">
               <label class="m-t-10 m-b-10 checkbox-inline"><input type="checkbox" name="back_at_end"><span x-l10n>Back option for all branches</span></label>
             </div>
+            <div class="col-sm-6 hide-for-non-cordova-ios">
+              <button id="ios-open-route-view" type="button" class="btn btn-primary">Open output audio manager</button>
+            </div>
           </div>
         </div>
       </div>
@@ -166,8 +169,15 @@
                     <input class="form-control btn-lg" type="range" step="0.01" min="0.01" max="4" data-default="1" id="auditory_cue_first_run_voice_options.rateMul" name="auditory_cue_first_run_voice_options.rateMul" data-validator="number" data-disp="#disp-auditory_cue_first_run_voice_options__rateMul">
                   </div>
                 </div>
-                <div class="col-sm-6 visible-for-cordova">
-                  <label class="checkbox-inline"><input type="checkbox" name="auditory_cue_first_run_voice_options.override_to_speaker"><span x-l10n>Override to speaker</span></label>
+                <div class="col-sm-12 hide-for-non-cordova-ios">
+                  <div class="form-group">
+                    <label>Override output</label>
+                    <div class="radio-group">
+                      <label class="radio-inline"><input type="radio" name="auditory_cue_first_run_voice_options.override_output" value=""><span x-l10n>None</span></label>
+                      <label class="radio-inline"><input type="radio" name="auditory_cue_first_run_voice_options.override_output" value="builtinspeaker"><span x-l10n>Builtin Speaker</span></label>
+                      <label class="radio-inline"><input type="radio" name="auditory_cue_first_run_voice_options.override_output" value="headphone"><span x-l10n>Headphone</span></label>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -210,7 +220,7 @@
               </div>
             </div>
             <div class="col-sm-4">
-              <div class="form-group hide-for-cordova">
+              <div class="form-group hide-for-cordova-ios">
                 <label for="ignore_key_release_time" x-l10n>Ignore key presses under n ms</label>
                 <input class="form-control" type="number" id="ignore_key_release_time" name="ignore_key_release_time" value="0" data-validator="number" data-dependent="#ignore_key_release_time_range">
                 <input type="range" id="ignore_key_release_time_range" class="form-control btn-lg" step="100" min="0" max="2000" data-dependent="#ignore_key_release_time">
@@ -255,8 +265,15 @@
                 <input class="form-control btn-lg" type="range" step="0.01" min="0.01" max="4" data-default="1" id="auditory_cue_voice_options.rateMul" name="auditory_cue_voice_options.rateMul" data-validator="number" data-disp="#disp-auditory_cue_voice_options__rateMul">
               </div>
             </div>
-            <div class="col-sm-6 visible-for-cordova">
-              <label class="checkbox-inline"><input type="checkbox" name="auditory_cue_voice_options.override_to_speaker"><span x-l10n>Override to speaker</span></label>
+            <div class="col-sm-12 hide-for-non-cordova-ios">
+              <div class="form-group">
+                <label>Override output</label>
+                <div class="radio-group">
+                  <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value=""><span x-l10n>None</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value="builtinspeaker"><span x-l10n>Builtin Speaker</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value="headphone"><span x-l10n>Headphone</span></label>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -291,8 +308,15 @@
                 <input class="form-control btn-lg" type="range" step="0.01" min="0.01" max="4" data-default="1" id="auditory_main_voice_options.rateMul" name="auditory_main_voice_options.rateMul" data-validator="number" data-disp="#disp-auditory_main_voice_options__rateMul">
               </div>
             </div>
-            <div class="col-sm-6 visible-for-cordova">
-              <label class="checkbox-inline"><input type="checkbox" name="auditory_main_voice_options.override_to_speaker"><span x-l10n>Override to speaker</span></label>
+            <div class="col-sm-12 hide-for-non-cordova-ios">
+              <div class="form-group">
+                <label>Override output</label>
+                <div class="radio-group">
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value=""><span x-l10n>None</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value="builtinspeaker"><span x-l10n>Builtin Speaker</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value="headphone"><span x-l10n>Headphone</span></label>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -437,14 +461,14 @@
           <div class="modal-body">
             <div class="row">
               <div class="col-xs-12">
-                <p class="visible-for-cordova" x-l10n>You can share or save the zip file.<p>
+                <p class="hide-for-non-cordova" x-l10n>You can share or save the zip file.<p>
                 <p class="hide-for-cordova" x-l10n>Please click on download.<p>
               </div>
             </div>
             <div class="row">
               <div class="col-xs-12">
                 <a id="save-file--open-btn" href class="hide-for-cordova btn btn-success btn-lg">Download</a>
-                <a id="save-file--share-btn" href class="visible-for-cordova btn btn-primary btn-lg">Share</a>
+                <a id="save-file--share-btn" href class="hide-for-non-cordova btn btn-primary btn-lg">Share</a>
               </div>
             </div>
           </div>

--- a/html/js/NativeAccessApi.js
+++ b/html/js/NativeAccessApi.js
@@ -40,7 +40,7 @@
     'is_software_keyboard_visible',
     'request_audio_record_permission',
     'add_key_command', 'remove_key_command',
-    'override_output_to_speaker',
+    'override_output', 'ios_open_manage_output_audio_view'
   ];
 
   for(var i = 0, len = direct_delegates.length; i < len; ++i)

--- a/html/js/edit-config.js
+++ b/html/js/edit-config.js
@@ -107,6 +107,12 @@ function _fix_config(cfg) {
 }
 
 function bind_dom_event_handlers () {
+  $('#ios-open-route-view').click(function ($evt) {
+    $evt.preventDefault();
+    if (speaku.is_native) {
+      speaku.api.ios_open_manage_output_audio_view()
+    }
+  });
   $('.vbl-btn').on('click', vbl_btn_onclick);
   function vbl_btn_onclick ($evt) {
     var vbl_link_id = $($evt.target).data('vbl');
@@ -1366,7 +1372,7 @@ function _vbl_voice_tmpl_options (locale) {
   });
   if (vlist.length == 0) {
     vlist = _.filter(all_voices, function (v) {
-      return v.locale.split('-')[0] == locale.split('-')[0];
+      return (v.locale+"").split('-')[0] == locale.split('-')[0];
     });
   }
   return _.map(vlist, function (v) {

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -1588,12 +1588,6 @@ function eval_config(config) {
   }
   if(!('can_edit' in config))
     config.can_edit = true;
-  config._has_override_to_speaker = _.filter([
-    'auditory_main_voice_options', 'auditory_cue_voice_options',
-    'auditory_cue_first_run_voice_options'
-  ], function(name) {
-    return config[name] && !!config[name].override_to_speaker;
-  }).length > 0;
   return config;
 }
 

--- a/html/quick-setup.html
+++ b/html/quick-setup.html
@@ -95,8 +95,15 @@
                   <input class="form-control btn-lg" type="range" step="0.01" min="0.01" max="4" data-default="1" id="auditory_cue_voice_options.rateMul" name="auditory_cue_voice_options.rateMul" data-validator="number" data-disp="#disp-auditory_cue_voice_options__rateMul">
                 </div>
               </div>
-              <div class="col-sm-6 visible-for-cordova">
-                <label class="checkbox-inline"><input type="checkbox" name="auditory_cue_voice_options.override_to_speaker" checked="True"><span x-l10n>Override to speaker</span></label>
+              <div class="col-sm-12 hide-for-non-cordova-ios">
+                <div class="form-group">
+                  <label>Override output</label>
+                  <div class="radio-group">
+                    <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value=""><span x-l10n>None</span></label>
+                    <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value="builtinspeaker"><span x-l10n>Builtin Speaker</span></label>
+                    <label class="radio-inline"><input type="radio" name="auditory_cue_voice_options.override_output" value="headphone"><span x-l10n>Headphone</span></label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -128,8 +135,14 @@
                   <input class="form-control btn-lg" type="range" step="0.01" min="0.01" max="4" data-default="1" id="auditory_main_voice_options.rateMul" name="auditory_main_voice_options.rateMul" data-validator="number" data-disp="#disp-auditory_main_voice_options__rateMul">
                 </div>
               </div>
-              <div class="col-sm-6 visible-for-cordova">
-                <label class="checkbox-inline"><input type="checkbox" name="auditory_main_voice_options.override_to_speaker" checked="True"><span x-l10n>Override to speaker</span></label>
+            <div class="col-sm-12 hide-for-non-cordova-ios">
+              <div class="form-group">
+                <label>Override output</label>
+                <div class="radio-group">
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value=""><span x-l10n>None</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value="builtinspeaker"><span x-l10n>Builtin Speaker</span></label>
+                  <label class="radio-inline"><input type="radio" name="auditory_main_voice_options.override_output" value="headphone"><span x-l10n>Headphone</span></label>
+                </div>
               </div>
             </div>
           </div>

--- a/html/scss/common.scss
+++ b/html/scss/common.scss
@@ -129,7 +129,7 @@ html.ios {
       margin-top: 100px;
     }
   }
-  .visible-for-ios {
+  .hide-for-non-ios {
     display: block;
   }
   .hide-for-ios {
@@ -137,22 +137,35 @@ html.ios {
   }
 }
 html.cordova {
-  .visible-for-cordova {
+  .hide-for-non-cordova {
     display: block;
   }
   .hide-for-cordova {
     display: none;
   }
 }
-
+html.cordova.ios {
+  .hide-for-non-cordova-ios {
+    display: block;
+  }
+  .hide-for-cordova-ios {
+    display: none;
+  }
+}
 html {
-  .visible-for-ios {
+  .hide-for-non-cordova-ios {
+    display: none;
+  }
+  .hide-for-cordova-ios {
+    display: block;
+  }
+  .hide-for-non-ios {
     display: none;
   }
   .hide-for-ios {
     display: block;
   }
-  .visible-for-cordova {
+  .hide-for-non-cordova {
     display: none;
   }
   .hide-for-cordova {


### PR DESCRIPTION

edit-config.js contains a new button in cordova-ios for opening audio output volume + route control.

Three option for overriding output audio. Each does what it says. None will not override and listen to what user did ask at audio manager...