### PR TITLE
fake scroll impl as a substitute for wheel event on ios

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -33,11 +33,13 @@
         <li><a class="icon-btn" href id="edit-mode-save-btn"><span class="far fa-save fa-2x"></span></a></li>
         <li><a class="icon-btn" href id="edit-mode-cancel-btn"><span class="far fa-times fa-2x"></span></a></li>
         <li class="on-debug-mode"><button class="btn btn-default" id="debug-clear-storage" type="button" x-l10n>Clear Storage</button></li>
+        <li class="on-debug-mode"><button class="btn btn-default" id="debug-with-fake-scroll-toggle">Wheel With Fake</button></li>
       </ul>
     </nav>
     <div id="theinput-wrp">
       <input id="theinput" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
     </div>
+    <div class="fake-scroll-elm"></div>
     <div id="tree-wrp">
       <div id="tree" class="resizable-content" oncontextmenu="return false">
       </div>

--- a/html/scss/main.scss
+++ b/html/scss/main.scss
@@ -283,6 +283,9 @@ body.rtl #tree {
       width: 450px;
     }
   }
+  & > .content { // do not display content at level zero
+    display: none;
+  }
 }
 
 body:not(.debug-mode) .on-debug-mode {
@@ -430,5 +433,26 @@ body.debug-mode .on-debug-mode {
 @media (max-width: 250px) {
   #edit-mode-btn, #edit-mode-save-btn, #edit-mode-cancel-btn {
     display: none;
+  }
+}
+
+
+// fake scrolls
+html.has-fake-scroll {
+  .main-top-navbar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+  }
+  #tree-wrp {
+    position: fixed;
+  }
+  .fake-scroll-elm {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    right: -120px;
+    bottom: -120px;
   }
 }


### PR DESCRIPTION
For testing this feature I did add a debug toggle Called "Wheel With Fake Scroll".
By pressing down `dot (.)` key debug buttons will show up.
Then it can get tested on non-ios platforms.