### PR TITLE
wheel-mode with-fake-scroll replace evt.pageX/Y with window.scrollX/Y

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -33,7 +33,7 @@
         <li><a class="icon-btn" href id="edit-mode-save-btn"><span class="far fa-save fa-2x"></span></a></li>
         <li><a class="icon-btn" href id="edit-mode-cancel-btn"><span class="far fa-times fa-2x"></span></a></li>
         <li class="on-debug-mode"><button class="btn btn-default" id="debug-clear-storage" type="button" x-l10n>Clear Storage</button></li>
-        <li class="on-debug-mode"><button class="btn btn-default" id="debug-with-fake-scroll-toggle">Wheel With Fake</button></li>
+        <li class="on-debug-mode"><button class="btn btn-default" id="debug-with-fake-scroll-toggle">Wheel With Fake Scroll</button></li>
       </ul>
     </nav>
     <div id="theinput-wrp">

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -56,7 +56,7 @@ Promise.all([
             } else {
               html.classList.remove('with-fake-scroll');
             }
-            el.innerHTML = "Wheel With Fake " + (active ? '[ON]' : '[OFF]');
+            el.innerHTML = "Wheel With Fake Scroll " + (active ? '[ON]' : '[OFF]');
             state = renew_state(state)
             start(state);
           });
@@ -724,8 +724,8 @@ function _on_keydown(down_ev) {
 function _on_scroll (evt) {
   if(!state || state._wheel_off)
     return;
-  var deltaX = evt.pageX - window._last_scroll_x,
-      deltaY = evt.pageY - window._last_scroll_y;
+  var deltaX = window.scrollX - window._last_scroll_x,
+      deltaY = window.scrollY - window._last_scroll_y;
   _on_wheel_subrout(deltaX, deltaY);
   // lock-the scroll
   var scrollX = window.scrollX > 110 || window.scrollX < 10 ? 60 : window.scrollX,
@@ -1500,8 +1500,8 @@ function _start_at_next_action(atree) {
     tmp_onwheel_subrout(evt.deltaX, evt.deltaY)
   }
   function tmp_onscroll (evt) {
-    var deltaX = evt.pageX - window._last_scroll_x,
-        deltaY = evt.pageY - window._last_scroll_y;
+    var deltaX = window.scrollX - window._last_scroll_x,
+        deltaY = window.scrollY - window._last_scroll_y;
     tmp_onwheel_subrout(deltaX, deltaY)
     // lock-the scroll
     var scrollX = window.scrollX > 110 || window.scrollX < 10 ? 60 : window.scrollX,


### PR DESCRIPTION
iOS's scroll event doesn't have `evt.pageX` or `pageY`. And since global variables `window.scrollX/Y` is available. I just did substitute them with the global variable related to it.