### PR TITLE
#164 & #147 + bugfix

### DIFF
--- a/html/edit-config.html
+++ b/html/edit-config.html
@@ -206,6 +206,10 @@
                     <label class="radio-inline"><input type="radio" name="helper_back_option" value="end"><span x-l10n>At end</span></label>
                     <label class="radio-inline"><input type="radio" name="helper_back_option" value=""><span x-l10n>None</span></label>
                   </div>
+                  <div class="col-sm-6">
+                    <h4 x-l10n>Stay in branch for all nodes</h3>
+                    <label class="checkbox-inline"><input type="checkbox" name="helper_stay_in_branch_for_all"><span x-l10n>On</span></label>
+                  </div>
                 </div>
               </div>
             </div><!-- /row -->

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -509,20 +509,32 @@ function _napi_remove_key_command() {
   }
 }
 function _start_prepare() {
-  if(!state.edit_mode && config.helper_back_option) {
-    var tree = state.positions[0].tree;
-    var content_template,
-        tmp = document.querySelector('#tree-node-template');
-    if(tmp)
-      content_template = _.template(tmp.innerHTML);
-    _start_auto_insert_back(tree, content_template, config.helper_back_option);
+  if (!state.edit_mode) {
+    if (config.helper_back_option) {
+      var tree = state.positions[0].tree;
+      var content_template,
+          tmp = document.querySelector('#tree-node-template');
+      if(tmp)
+        content_template = _.template(tmp.innerHTML);
+      _start_auto_insert_back(tree, content_template, config.helper_back_option);
+    }
+    if (config.helper_stay_in_branch_for_all) {
+      var tree = state.positions[0].tree;
+      _helper_add_stay_in_branch_for_all(tree)
+    }
   }
   return _napi_add_key_command();
 }
 function _stop_prepare() {
-  if(!state.edit_mode && config.back_at_end) {
-    var tree = state.positions[0].tree;
-    _stop_auto_remove_back(tree);
+  if (!state.edit_mode) {
+    if (config.back_at_end) {
+      var tree = state.positions[0].tree;
+      _stop_auto_remove_back(tree);
+    }
+    if (config.helper_stay_in_branch_for_all) {
+      var tree = state.positions[0].tree;
+      _helper_remove_stay_in_branch_for_all(tree)
+    }
   }
   return _napi_remove_key_command();
 }
@@ -547,7 +559,6 @@ function _start_auto_insert_back(tree, content_template) {
     }
   });
 }
-
 function _stop_auto_remove_back(tree) {
   _.each(tree.nodes, function(anode) {
     if(anode._back_node) {
@@ -556,6 +567,29 @@ function _stop_auto_remove_back(tree) {
     }
     if(!anode.is_leaf) {
       _stop_auto_remove_back(anode);
+    }
+  });
+}
+
+function _helper_add_stay_in_branch_for_all (tree) {
+  _.each(tree.nodes, function(anode) {
+    if (!anode.is_leaf) {
+      if (!('stay-in-branch' in anode.meta)) {
+        anode._helper_stay_in_branch_added = true;
+        anode.meta['stay-in-branch'] = 'true';
+      }
+      _helper_add_stay_in_branch_for_all(anode);
+    }
+  });
+}
+function _helper_remove_stay_in_branch_for_all (tree) {
+  if (tree._helper_stay_in_branch_added) {
+    delete tree._helper_stay_in_branch_added;
+    delete anode.meta['stay-in-branch']
+  }
+  _.each(tree.nodes, function(anode) {
+    if (!anode.is_leaf) {
+      _helper_add_stay_in_branch_for_all(anode);
     }
   });
 }
@@ -1666,11 +1700,33 @@ function _in_check_stay_in_branch (atree) {
   }
 }
 
+function _leaf_endit (anode) {
+  return pause()
+    .then(function() {
+      if(anode.content_element)
+        anode.content_element.classList.add('selected' || config.selected_class);
+      // speak it
+      return (_meta_true_check(anode.meta['no-main'], false) ?
+              Promise.resolve() : _move_sub_speak2.call(anode, 'main'))
+        .then(function() {
+          reset_state();
+          _resume_at_next_action(anode);
+        });
+    });
+}
+
+function _in_check_endit (anode) {
+  if (_meta_true_check(anode.meta['endit'])) {
+    return _leaf_endit(anode);
+  }
+}
+
 var _tree_select_override_functions = [
   _in_check_back_n_branch,
   _in_check_spell_delchar,
   _in_check_spell_default,
   _in_override_change_tree,
+  _in_check_endit,
   _in_check_stay_in_branch,
 ];
 function _tree_go_in() {
@@ -1719,18 +1775,7 @@ function _tree_go_in() {
     }
     // finish it
     // on auto mode stop iteration and on any key restart
-    return pause()
-      .then(function() {
-        if(atree.content_element)
-          atree.content_element.classList.add('selected' || config.selected_class);
-        // speak it
-        return (_meta_true_check(atree.meta['no-main'], false) ?
-                Promise.resolve() : _move_sub_speak2.call(atree, 'main'))
-          .then(function() {
-            reset_state();
-            _resume_at_next_action(atree);
-          });
-      });
+    return _leaf_endit(atree);
   } else {
     if(atree.nodes.length == 0)
       return Promise.resolve(); // has no leaf, nothing to do

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -546,7 +546,7 @@ function _start_auto_insert_back(tree, content_template) {
       if (config.helper_back_option == 'start') {
         insert_pos = 0;
       }
-      anode._back_node = tree_add_node(anode, insert_pos, {
+      anode._back_node = tree_insert_node(anode, insert_pos, {
         _more_meta: {
           istmp: true
         },
@@ -2042,7 +2042,11 @@ function _word_prediction_dynamic_nodes (anode) {
     throw new Error("No words file given for dyn=\"spell-word-prediction\"");
   }
   var txt = _get_current_spell_txt(),
-      max_nodes = anode.meta['max-nodes'] || 3;
+      max_nodes = anode.meta['max-nodes'] || 3,
+      nchars = parseInt(anode.meta['predict-after-n-chars']);
+  if (!isNaN(nchars) && txt.length < nchars) {
+    return Promise.resolve({ nodes: [] });
+  }
   return _get_prediction_spell_words(words_file, txt)
     .then(function (subwdata) {
       if (!subwdata.words_sorted) {
@@ -2070,13 +2074,17 @@ function _letter_prediction_dynamic_nodes (anode) {
   }
   var alphabet = anode.meta['alphabet'] || config.alphabet ||
                  'abcdefghijklmnopqrstuvwxyz', 
-      txt = _get_current_spell_txt();
+      txt = _get_current_spell_txt(),
+      nchars = parseInt(anode.meta['predict-after-n-chars']);
   if (typeof alphabet == 'string') {
     if (alphabet.indexOf(',') != -1) {
       alphabet = alphabet.split(',');
     } else {
       alphabet.split('');
     }
+  }
+  if (!isNaN(nchars) && txt.length < nchars) {
+    return Promise.resolve({ nodes: [] });
   }
   return _get_prediction_spell_words(words_file, txt)
     .then(function (subwdata) {

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -1700,7 +1700,7 @@ function _in_check_stay_in_branch (atree) {
   }
 }
 
-function _leaf_endit (anode) {
+function _leaf_select_utterance (anode) {
   return pause()
     .then(function() {
       if(anode.content_element)
@@ -1715,9 +1715,9 @@ function _leaf_endit (anode) {
     });
 }
 
-function _in_check_endit (anode) {
-  if (_meta_true_check(anode.meta['endit'])) {
-    return _leaf_endit(anode);
+function _in_check_select_utterance (anode) {
+  if (_meta_true_check(anode.meta['select-utterance'])) {
+    return _leaf_select_utterance(anode);
   }
 }
 
@@ -1726,7 +1726,7 @@ var _tree_select_override_functions = [
   _in_check_spell_delchar,
   _in_check_spell_default,
   _in_override_change_tree,
-  _in_check_endit,
+  _in_check_select_utterance,
   _in_check_stay_in_branch,
 ];
 function _tree_go_in() {
@@ -1775,7 +1775,7 @@ function _tree_go_in() {
     }
     // finish it
     // on auto mode stop iteration and on any key restart
-    return _leaf_endit(atree);
+    return _leaf_select_utterance(atree);
   } else {
     if(atree.nodes.length == 0)
       return Promise.resolve(); // has no leaf, nothing to do

--- a/html/trees/Spell_Prediction/ar-Spell_Prediction.md
+++ b/html/trees/Spell_Prediction/ar-Spell_Prediction.md
@@ -1,4 +1,4 @@
 <meta data-spell-branch  data-spell-update-dyn-onchange>
-- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/ar.json" data-max-nodes="3" data-spell-finish>
+- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/ar.json" data-max-nodes="3" data-spell-finish data-predict-after-n-chars="3">
 - <meta data-dyn="spell-letter-prediction" data-words-file="trees/Spell_Prediction/ar.json" data-alphabet="چجحخهعغفقثصضگکمنتالبیسشوپدذرزطظ">
 - إنهاء<meta data-spell-finish>

--- a/html/trees/Spell_Prediction/cy-Spell_Prediction.md
+++ b/html/trees/Spell_Prediction/cy-Spell_Prediction.md
@@ -1,5 +1,5 @@
 <meta data-spell-branch  data-spell-update-dyn-onchange>
-- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/cy-bangor_CEG.json" data-max-nodes="3" data-spell-finish>
+- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/cy-bangor_CEG.json" data-max-nodes="3" data-spell-finish data-predict-after-n-chars="3">
 - <meta data-dyn="spell-letter-prediction" data-words-file="trees/Spell_Prediction/cy-bangor_CEG.json">
 - Gofod <meta data-spell-letter=" ">
 - Dadwneud <meta data-spell-delchar>

--- a/html/trees/Spell_Prediction/en-GB-Spell_Prediction.md
+++ b/html/trees/Spell_Prediction/en-GB-Spell_Prediction.md
@@ -1,5 +1,5 @@
 <meta data-spell-branch  data-spell-update-dyn-onchange>
-- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/bncfrequency.json" data-max-nodes="3" data-spell-finish>
+- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/bncfrequency.json" data-max-nodes="3" data-spell-finish data-predict-after-n-chars="3">
 - <meta data-dyn="spell-letter-prediction" data-words-file="trees/Spell_Prediction/bncfrequency.json">
 - Space <meta data-spell-letter=" ">
 - Undo <meta data-spell-delchar>

--- a/html/trees/Spell_Prediction/es-ES-Spell_Prediction.md
+++ b/html/trees/Spell_Prediction/es-ES-Spell_Prediction.md
@@ -1,5 +1,5 @@
 <meta data-spell-branch  data-spell-update-dyn-onchange>
-- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/es-subtlex-esp.json" data-max-nodes="3" data-spell-finish>
+- <meta data-dyn="spell-word-prediction" data-words-file="trees/Spell_Prediction/es-subtlex-esp.json" data-max-nodes="3" data-spell-finish data-predict-after-n-chars="3">
 - <meta data-dyn="spell-letter-prediction" data-words-file="trees/Spell_Prediction/es-subtlex-esp.json" data-alphabet="aábcdefghijklmnñoópqrstuüvwxyz">
 - Espacio <meta data-spell-letter=" ">
 - Deshacer <meta data-spell-delchar>

--- a/html/trees/Spell_by_blocks_in_frequency/en-GB-Spell_by_blocks_in_frequency.md
+++ b/html/trees/Spell_by_blocks_in_frequency/en-GB-Spell_by_blocks_in_frequency.md
@@ -1,4 +1,4 @@
-## I shall spell it (spell)<meta data-onselect-continue-in-branch data-onselect-continue-concat>
+## I shall spell it (spell)<meta data-spell-branch>
 
 ### e to u
 


### PR DESCRIPTION
 stayinbranch for all helper + meta-endit

1. A new checkbox in helper section to toggle stay-in-branch for all nodes other than root node.
2. Use of `<meta data-select-utterance>` will result in a node to explicitly end the process and select that node.

 word prediction meta predict-after-n-chars #147 + bugfix

1. Adding meta `predict-after-n-chars="number"` to any predict dynnode will
   not show any suggestions until supplied number of chars has been selected.
2. Add missing code for flexbox layout change. '.children-wrp'.
3. A bugfix related to back helper option at beginning. It was showing the
   back option after suggestions (not at beginning).
   By using `tree_insert_node` instead of `tree_add_node`
   it accounts for dynnode's with empty elements when inserting a new node.