### PR TITLE
Fix #218 by wrapping `getVoices` in setTimeout

### DIFF
--- a/html/js/core.js
+++ b/html/js/core.js
@@ -1169,13 +1169,19 @@ proto.get_voices = function() {
     return this.api.get_voices();
   } else {
     // this.responsiveVoice.getVoices()
-    return Promise.resolve(_.map(speechSynthesis.getVoices(), function(v) {
-      return {
-        id: v.voiceURI,
-        label: v.name,
-        locale: v.lang||''
-      };
-    }));
+    return new Promise(function(res) {
+      setTimeout(function() {
+        res(
+          _.map(speechSynthesis.getVoices(), function(v) {
+            return {
+              id: v.voiceURI,
+              label: v.name,
+              locale: v.lang || '',
+            };
+          })
+        );
+      }, 0);
+    });
   }
 }
 


### PR DESCRIPTION
This PR fixes #218 by wrapping the call to the `speechSynthesis` API in a setTimeout (that waits for 0ms) so that chrome can delay the call for a few microtasks which gives it time to load the voices in.